### PR TITLE
Fix CMakeLists.txt

### DIFF
--- a/demo-serving/CMakeLists.txt
+++ b/demo-serving/CMakeLists.txt
@@ -5,11 +5,23 @@ if (NOT EXISTS
                 --output-document
                 ${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid/text_classification_lstm.tar.gz)
 
-            execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf
                 "${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid/text_classification_lstm.tar.gz"
                 WORKING_DIRECTORY
                 ${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid
                 )
+endif()
+
+if (NOT EXISTS
+                ${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid/ctr_prediction)
+        execute_process(COMMAND wget --no-check-certificate
+                https://paddle-serving.bj.bcebos.com/data/ctr_prediction/ctr_prediction.tar.gz
+                --output-document
+                ${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid/ctr_prediction.tar.gz)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf
+                "${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid/ctr_prediction.tar.gz"
+                WORKING_DIRECTORY
+                ${CMAKE_CURRENT_LIST_DIR}/data/model/paddle/fluid)
 endif()
 
 include_directories(SYSTEM  ${CMAKE_CURRENT_LIST_DIR}/../kvdb/include)


### PR DESCRIPTION
Because CTR model file size is too large, put the model to BCE and add command to download it during cmake.
