### PR TITLE
Fix mklml lib

### DIFF
--- a/cmake/paddlepaddle.cmake
+++ b/cmake/paddlepaddle.cmake
@@ -65,6 +65,9 @@ ExternalProject_Add(
 )
 
 ExternalProject_Get_Property(extern_paddle BINARY_DIR)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}" "${BINARY_DIR}/fluid_install_dir/third_party/install/mklml/lib")
+LINK_DIRECTORIES(${BINARY_DIR}/fluid_install_dir/third_party/install/mklml/lib)
+
 ADD_LIBRARY(paddle_fluid STATIC IMPORTED GLOBAL)
 SET_PROPERTY(TARGET paddle_fluid PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_install_dir/paddle/fluid/inference/libpaddle_fluid.a)
 
@@ -76,15 +79,7 @@ SET_PROPERTY(TARGET snappystream PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_
 ADD_LIBRARY(xxhash STATIC IMPORTED GLOBAL)
 SET_PROPERTY(TARGET xxhash PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_install_dir/third_party/install/xxhash/lib/libxxhash.a)
 
-ADD_LIBRARY(iomp5 SHARED IMPORTED GLOBAL)
-SET_PROPERTY(TARGET iomp5 PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_install_dir/third_party/install/mklml/lib/libiomp5.so)
-
-ADD_LIBRARY(mklml_intel SHARED IMPORTED GLOBAL)
-SET_PROPERTY(TARGET mklml_intel PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_install_dir/third_party/install/mklml/lib/libmklml_intel.so)
-
 LIST(APPEND paddle_depend_libs
         snappystream
         snappy
-        iomp5
-        mklml_intel
         xxhash)

--- a/demo-serving/CMakeLists.txt
+++ b/demo-serving/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(serving kvdb rocksdb)
 if(WITH_GPU)
     target_link_libraries(serving ${CUDA_LIBRARIES})
 endif()
-target_link_libraries(serving iomp5 mklml_intel -lpthread
+target_link_libraries(serving -liomp5 -lmklml_intel -lpthread
         -lcrypto -lm -lrt -lssl -ldl -lz -lbz2)
 
 install(TARGETS serving


### PR DESCRIPTION
动态链接库在CMake里要用-lmklml指定

如果用下面方式会出现RPATH的问题：

```
ADD_LIBRARY(mklml_intel SHARED IMPORTED GLOBAL)
SET_PROPERTY(TARGET mklml_intel PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/fluid_install_dir/third_party/install/mklml/lib/libmklml_intel.so)

target_link_libraries(serving mklml_intel -lpthread -lssl)
```
这时链接出来的serving可执行文件，记录的libmklml_intel.so的路径是一个带路径的文件名，运行时会严格按照各路径去找动态库，导致失败