### PR TITLE
Ctr model serving

### DIFF
--- a/demo-client/src/ctr_prediction.cpp
+++ b/demo-client/src/ctr_prediction.cpp
@@ -38,7 +38,7 @@ DEFINE_int32(batch_size, 50, "Set the batch size of test file.");
 DEFINE_int32(concurrency, 1, "Set the max concurrency of requests");
 DEFINE_int32(repeat, 1, "Number of data samples iteration count. Default 1");
 DEFINE_bool(enable_profiling,
-            true,
+            false,
             "Enable profiling. Will supress a lot normal output");
 
 std::vector<float> cont_min = {0, -3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};

--- a/demo-serving/op/ctr_prediction_op.cpp
+++ b/demo-serving/op/ctr_prediction_op.cpp
@@ -160,6 +160,15 @@ int CTRPredictionOp::inference() {
       cube_time_us_ += usec;
       ++cube_req_num_;
       cube_req_key_num_ += keys.size();
+
+      if (cube_req_num_ >= 1000) {
+        LOG(INFO) << "Cube request count: " << cube_req_num_;
+        LOG(INFO) << "Cube request key count: " << cube_req_key_num_;
+        LOG(INFO) << "Cube request total time: " << cube_time_us_ << "us";
+        LOG(INFO) << "Average " << cube_time_us_ / cube_req_num_ << "us/req";
+        LOG(INFO) << "Average " << cube_time_us_ / cube_req_key_num_
+                  << "us/key";
+      }
       mutex_.unlock();
     } else {
       ret = cube->seek(table_name, keys, &values);

--- a/demo-serving/op/ctr_prediction_op.cpp
+++ b/demo-serving/op/ctr_prediction_op.cpp
@@ -164,8 +164,12 @@ int CTRPredictionOp::inference() {
       LOG(INFO) << "Cube request count: " << cube_req_num_;
       LOG(INFO) << "Cube request key count: " << cube_req_key_num_;
       LOG(INFO) << "Cube request total time: " << cube_time_us_ << "us";
-      LOG(INFO) << "Average " << cube_time_us_ / cube_req_num_ << "us/req";
-      LOG(INFO) << "Average " << cube_time_us_ / cube_req_key_num_ << "us/key";
+      LOG(INFO) << "Average "
+                << static_cast<float>(cube_time_us_) / cube_req_num_
+                << "us/req";
+      LOG(INFO) << "Average "
+                << static_cast<float>(cube_time_us_) / cube_req_key_num_
+                << "us/key";
 
       cube_time_us_ = 0;
       cube_req_num_ = 0;

--- a/demo-serving/op/ctr_prediction_op.h
+++ b/demo-serving/op/ctr_prediction_op.h
@@ -55,6 +55,7 @@ static const char* CTR_PREDICTION_MODEL_NAME = "ctr_prediction";
  * and modifications we made
  *
  */
+
 class CTRPredictionOp
     : public baidu::paddle_serving::predictor::OpWithChannel<
           baidu::paddle_serving::predictor::ctr_prediction::Response> {
@@ -64,6 +65,12 @@ class CTRPredictionOp
   DECLARE_OP(CTRPredictionOp);
 
   int inference();
+
+ private:
+  static bthread::Mutex mutex_;
+  static int64_t cube_time_us_;
+  static int32_t cube_req_num_;
+  static int32_t cube_req_key_num_;
 };
 
 }  // namespace serving

--- a/predictor/common/constant.h
+++ b/predictor/common/constant.h
@@ -40,8 +40,6 @@ DECLARE_int32(reload_interval_s);
 DECLARE_bool(enable_model_toolkit);
 DECLARE_string(enable_protocol_list);
 DECLARE_bool(enable_cube);
-DECLARE_string(cube_config_path);
-DECLARE_string(cube_config_file);
 
 // STATIC Variables
 extern const char* START_OP_NAME;

--- a/predictor/framework/infer.h
+++ b/predictor/framework/infer.h
@@ -632,7 +632,6 @@ class VersionedInferEngine : public InferEngine {
         LOG(ERROR) << "Failed thrd clear version engine: " << iter->first;
         return -1;
       }
-      LOG(INFO) << "Succ thrd clear version engine: " << iter->first;
     }
     return 0;
   }

--- a/predictor/framework/resource.cpp
+++ b/predictor/framework/resource.cpp
@@ -208,7 +208,6 @@ int Resource::thread_clear() {
     return -1;
   }
 
-  LOG(INFO) << bthread_self() << "Resource::thread_clear success";
   // ...
   return 0;
 }

--- a/predictor/src/pdserving.cpp
+++ b/predictor/src/pdserving.cpp
@@ -69,6 +69,9 @@ static bvar::PassiveStatus<std::string> s_predictor_revision(
 
 DEFINE_bool(V, false, "print version, bool");
 DEFINE_bool(g, false, "user defined gflag path");
+DEFINE_bool(enable_ctr_profiling,
+            false,
+            "Enable profiling in CTR prediction demo");
 DECLARE_string(flagfile);
 
 namespace bthread {

--- a/predictor/src/pdserving.cpp
+++ b/predictor/src/pdserving.cpp
@@ -51,8 +51,6 @@ using baidu::paddle_serving::predictor::FLAGS_port;
 using baidu::paddle_serving::configure::InferServiceConf;
 using baidu::paddle_serving::configure::read_proto_conf;
 
-DECLARE_bool(logtostderr);
-
 void print_revision(std::ostream& os, void*) {
 #if defined(PDSERVING_VERSION)
   os << PDSERVING_VERSION;
@@ -69,9 +67,6 @@ static bvar::PassiveStatus<std::string> s_predictor_revision(
 
 DEFINE_bool(V, false, "print version, bool");
 DEFINE_bool(g, false, "user defined gflag path");
-DEFINE_bool(enable_ctr_profiling,
-            false,
-            "Enable profiling in CTR prediction demo");
 DECLARE_string(flagfile);
 
 namespace bthread {
@@ -220,7 +215,8 @@ int main(int argc, char** argv) {
   }
   LOG(INFO) << "Succ initialize cube";
 
-  FLAGS_logtostderr = false;
+  // FATAL messages are output to stderr
+  FLAGS_stderrthreshold = 3;
 
   if (ServerManager::instance().start_and_wait() != 0) {
     LOG(ERROR) << "Failed start server and wait!";

--- a/sdk-cpp/src/endpoint.cpp
+++ b/sdk-cpp/src/endpoint.cpp
@@ -64,7 +64,6 @@ int Endpoint::thrd_clear() {
       return -1;
     }
   }
-  LOG(INFO) << "Succ thrd clear all vars: " << var_size;
   return 0;
 }
 

--- a/sdk-cpp/src/predictor_sdk.cpp
+++ b/sdk-cpp/src/predictor_sdk.cpp
@@ -94,8 +94,6 @@ int PredictorApi::thrd_clear() {
       LOG(ERROR) << "Failed thrd clear endpoint:" << it->first;
       return -1;
     }
-
-    LOG(INFO) << "Succ thrd clear endpoint:" << it->first;
   }
   return 0;
 }


### PR DESCRIPTION
CTR预估任务中增加profiling模式：
1) Serving端每1000个请求，将访问cube的时间统计信息打印到日志
2) Client端增加--enable_profiling和--concurrency参数，以利用client向serving端发压