### PR TITLE
fix criteo ctr model download url

### DIFF
--- a/python/examples/criteo_ctr/get_data.sh
+++ b/python/examples/criteo_ctr/get_data.sh
@@ -1,2 +1,2 @@
-wget https://paddle-serving.bj.bcebos.com/data%2Fctr_prediction%2Fctr_data.tar.gz
+wget --no-check-certificate https://paddle-serving.bj.bcebos.com/data/ctr_prediction/ctr_data.tar.gz
 tar -zxvf *ctr_data.tar.gz


### PR DESCRIPTION
make criteo training data download path clear