### PR TITLE
Refine benchmark scripts

### DIFF
--- a/python/examples/fit_a_line/benchmark.py
+++ b/python/examples/fit_a_line/benchmark.py
@@ -1,0 +1,35 @@
+from paddle_serving_client import Client
+from paddle_serving_client.utils import MultiThreadRunner
+from paddle_serving_client.utils import benchmark_args
+import time
+import paddle
+import sys
+import requests
+
+args = benchmark_args()
+
+def single_func(idx, resource):
+    if args.request == "rpc":
+        client = Client()
+        client.load_client_config(args.model)
+        client.connect([args.endpoint])
+        train_reader = paddle.batch(paddle.reader.shuffle(
+            paddle.dataset.uci_housing.train(), buf_size=500), batch_size=1)
+        start = time.time()
+        for data in train_reader():
+            fetch_map = client.predict(feed={"x": data[0][0]}, fetch=["price"])
+        end = time.time()
+        return [[end - start]]
+    elif args.request == "http":
+        train_reader = paddle.batch(paddle.reader.shuffle(
+            paddle.dataset.uci_housing.train(), buf_size=500), batch_size=1)
+        start = time.time()
+        for data in train_reader():
+            r = requests.post('http://{}/uci/prediction'.format(args.endpoint),
+                              data = {"x": data[0]})
+        end = time.time()
+        return [[end - start]]
+
+multi_thread_runner = MultiThreadRunner()
+result = multi_thread_runner.run(single_func, args.thread, {})
+print(result)

--- a/python/examples/fit_a_line/benchmark.py
+++ b/python/examples/fit_a_line/benchmark.py
@@ -1,3 +1,16 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from paddle_serving_client import Client
 from paddle_serving_client.utils import MultiThreadRunner
 from paddle_serving_client.utils import benchmark_args

--- a/python/paddle_serving_client/utils/__init__.py
+++ b/python/paddle_serving_client/utils/__init__.py
@@ -11,16 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import sys
 import subprocess
+import argparse
 from multiprocessing import Pool
+
+def benchmark_args():
+    parser = argparse.ArgumentParser("benchmark")
+    parser.add_argument("--thread", type=int, default=10, help="concurrecy")
+    parser.add_argument("--model", type=str, default="", help="model for evaluation")
+    parser.add_argument("--endpoint", type=str, default="127.0.0.1:9292", help="endpoint of server")
+    parser.add_argument("--request", type=str, default="rpc", help="mode of service")
+    return parser.parse_args()
+
 
 class MultiThreadRunner(object):
     def __init__(self):
         pass
 
     def run(self, thread_func, thread_num, global_resource):
+        os.environ["http_proxy"] = ""
+        os.environ["https_proxy"] = ""
         p = Pool(thread_num)
         result_list = []
         for i in range(thread_num):


### PR DESCRIPTION
unify benchmark script, for rpc service
``` shell
python -m paddle_serving_server.serve --model serving_server_model/ --port 9393 --thread 10
```
``` shell
python benchmark.py --thread 30 --model uci_housing_client/serving_client_conf.prototxt --endpoint 127.0.0.1:9393 --request rpc
```
for http service
``` shell
python -m paddle_serving_server.web_serve --model serving_server_model/ --port 9393 --thread 10 --name uci
```
``` shell
python benchmark.py --thread 30 --model uci_housing_client/serving_client_conf.prototxt --endpoint 127.0.0.1:9393 --request http
```
