### PR TITLE
remove stdout print in endpoint.cpp

### DIFF
--- a/core/sdk-cpp/src/endpoint.cpp
+++ b/core/sdk-cpp/src/endpoint.cpp
@@ -75,7 +75,7 @@ int Endpoint::thrd_finalize() {
       return -1;
     }
   }
-  LOG(INFO) << "Succ thrd finalize all vars: " << var_size;
+  VLOG(2) << "Succ thrd finalize all vars: " << var_size;
   return 0;
 }
 


### PR DESCRIPTION
the client can not be used during Paddle training. The reason is that endpoint.cpp has a stdout print that can make data_generator crash.