### PR TITLE
support py3 runtime&devel docker env

### DIFF
--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -4,19 +4,19 @@
 
 ## Compilation environment requirements
 
-- os: CentOS 6u3
-- gcc: 4.8.2 and later
-- go: 1.9.2 and later
-- git：2.17.1 and later
-- cmake：3.2.2 and later
-- python：2.7.2 and later
+- OS: CentOS 7
+- GCC: 4.8.2 and later
+- Golang: 1.9.2 and later
+- Git：2.17.1 and later
+- CMake：3.2.2 and later
+- Python：2.7.2 and later
 
 It is recommended to use Docker for compilation. We have prepared the Paddle Serving compilation environment for you: 
 
 - CPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-devel`，dockerfile: [Dockerfile.devel](../tools/Dockerfile.devel)
 - GPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-gpu-devel`，dockerfile: [Dockerfile.gpu.devel](../tools/Dockerfile.gpu.devel)
 
-This document will take Python2 as an example to show how to compile Paddle Serving. If you want to compile with Python 3, just adjust the python options of cmake.
+This document will take Python2 as an example to show how to compile Paddle Serving. If you want to compile with Python 3, just adjust the Python options of cmake.
 
 ## Get Code
 

--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -11,7 +11,12 @@
 - cmake：3.2.2 and later
 - python：2.7.2 and later
 
-It is recommended to use Docker to prepare the compilation environment for the Paddle service: [CPU Dockerfile.devel](../tools/Dockerfile.devel), [GPU Dockerfile.gpu.devel](../tools/Dockerfile.gpu.devel)
+It is recommended to use Docker for compilation. We have prepared the Paddle Serving compilation environment for you: 
+
+- CPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-devel`，dockerfile: [Dockerfile.devel](../tools/Dockerfile.devel)
+- GPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-gpu-devel`，dockerfile: [Dockerfile.gpu.devel](../tools/Dockerfile.gpu.devel)
+
+This document will take Python2 as an example to show how to compile Paddle Serving. If you want to compile with Python 3, just adjust the python options of cmake.
 
 ## Get Code
 

--- a/doc/COMPILE_CN.md
+++ b/doc/COMPILE_CN.md
@@ -4,12 +4,12 @@
 
 ## 编译环境设置
 
-- os: CentOS 6u3
-- gcc: 4.8.2及以上
-- go: 1.9.2及以上
-- git：2.17.1及以上
-- cmake：3.2.2及以上
-- python：2.7.2及以上
+- OS: CentOS 7
+- GCC: 4.8.2及以上
+- Golang: 1.9.2及以上
+- Git：2.17.1及以上
+- CMake：3.2.2及以上
+- Python：2.7.2及以上
 
 推荐使用Docker编译，我们已经为您准备好了Paddle Serving编译环境：
 

--- a/doc/COMPILE_CN.md
+++ b/doc/COMPILE_CN.md
@@ -11,7 +11,12 @@
 - cmake：3.2.2及以上
 - python：2.7.2及以上
 
-推荐使用Docker准备Paddle Serving编译环境：[CPU Dockerfile.devel](../tools/Dockerfile.devel)，[GPU Dockerfile.gpu.devel](../tools/Dockerfile.gpu.devel)
+推荐使用Docker编译，我们已经为您准备好了Paddle Serving编译环境：
+
+- CPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-devel`，dockerfile: [Dockerfile.devel](../tools/Dockerfile.devel)
+- GPU: `hub.baidubce.com/paddlepaddle/serving:0.2.0-gpu-devel`，dockerfile: [Dockerfile.gpu.devel](../tools/Dockerfile.gpu.devel)
+
+本文档将以Python2为例介绍如何编译Paddle Serving。如果您想用Python3进行编译，只需要调整cmake的Python相关选项即可。
 
 ## 获取代码
 

--- a/doc/RUN_IN_DOCKER.md
+++ b/doc/RUN_IN_DOCKER.md
@@ -6,6 +6,8 @@
 
 Docker (GPU version requires nvidia-docker to be installed on the GPU machine)
 
+This document takes Python2 as an example to show how to run Paddle Serving in docker. You can also use Python3 to run related commands by replacing `python` with `python3`.
+
 ## CPU
 
 ### Get docker image

--- a/doc/RUN_IN_DOCKER_CN.md
+++ b/doc/RUN_IN_DOCKER_CN.md
@@ -6,6 +6,8 @@
 
 Docker（GPU版本需要在GPU机器上安装nvidia-docker）
 
+该文档以Python2为例展示如何在Docker中运行Paddle Serving，您也可以通过将`python`更换成`python3`来用Python3运行相关命令。
+
 ## CPU版本
 
 ### 获取镜像

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:7.3.1611
 RUN yum -y install wget && \
     yum -y install epel-release && yum -y install patchelf && \
     yum -y install gcc make python-devel && \
+    yum -y install python3 python3-devel && \
     yum clean all && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && rm get-pip.py

--- a/tools/Dockerfile.ci
+++ b/tools/Dockerfile.ci
@@ -26,6 +26,8 @@ RUN yum -y install wget >/dev/null \
     && make >/dev/null && make install >/dev/null \
     && cd .. \
     && rm -rf patchelf-0.10* \
+    && yum install -y python3 python3-devel \
+    && pip3 install google protobuf setuptools wheel flask \
     && yum -y update >/dev/null \
     && yum -y install dnf >/dev/null \
     && yum -y install dnf-plugins-core >/dev/null \

--- a/tools/Dockerfile.devel
+++ b/tools/Dockerfile.devel
@@ -18,5 +18,7 @@ RUN yum -y install wget >/dev/null \
     && python get-pip.py >/dev/null \
     && pip install google protobuf setuptools wheel flask >/dev/null \
     && rm get-pip.py \
+    && yum install -y python3 python3-devel \
+    && pip3 install google protobuf setuptools wheel flask \
     && yum -y install epel-release && yum -y install patchelf \
     && yum clean all

--- a/tools/Dockerfile.gpu
+++ b/tools/Dockerfile.gpu
@@ -6,6 +6,7 @@ RUN yum -y install wget && \
     yum -y install libSM-1.2.2-2.el7.x86_64 --setopt=protected_multilib=false && \
     yum -y install libXrender-0.9.10-1.el7.x86_64 --setopt=protected_multilib=false && \
     yum -y install libXext-1.3.3-3.el7.x86_64 --setopt=protected_multilib=false && \
+    yum -y install python3 python3-devel && \
     yum clean all && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && rm get-pip.py && \

--- a/tools/Dockerfile.gpu.devel
+++ b/tools/Dockerfile.gpu.devel
@@ -19,5 +19,7 @@ RUN yum -y install wget >/dev/null \
     && python get-pip.py >/dev/null \
     && pip install google protobuf setuptools wheel flask >/dev/null \
     && rm get-pip.py \
+    && yum install -y python3 python3-devel \
+    && pip3 install google protobuf setuptools wheel flask \
     && yum -y install epel-release && yum -y install patchelf \
     && yum clean all


### PR DESCRIPTION
- 添加了支持py2和py3的运行&开发镜像
   - hub.baidubce.com/paddlepaddle/serving:0.2.0 (329M->441M)
   - hub.baidubce.com/paddlepaddle/serving:0.2.0-devel
   - hub.baidubce.com/paddlepaddle/serving:0.2.0-gpu (1.31G->1.53G)
   - hub.baidubce.com/paddlepaddle/serving:0.2.0-gpu-devel
   - dockerhub: barriery/serving:\<tag\>
- COMPILE文档添加了py3的说明（以py2为例，调整cmake选项即可用py3编译）
- RUN_IN_DOCKER文档添加了py3的说明（以py2为例，可以通过将`python`更换成`python3`来用Python3运行相关命令）

fix #436