### PR TITLE
use memory address instead of timestamp

### DIFF
--- a/python/paddle_serving_client/__init__.py
+++ b/python/paddle_serving_client/__init__.py
@@ -18,7 +18,6 @@ import os
 from .proto import sdk_configure_pb2 as sdk
 from .proto import general_model_config_pb2 as m_config
 import google.protobuf.text_format
-import time
 import sys
 
 int_type = 0
@@ -156,8 +155,7 @@ class Client(object):
                 )
         else:
             if self.predictor_sdk_ is None:
-                timestamp = time.time()
-                self.add_variant('default_tag_{}'.format(timestamp), endpoints,
+                self.add_variant('default_tag_{}'.format(id(self)), endpoints,
                                  100)
             else:
                 print(


### PR DESCRIPTION
使用时间戳作为variant的default_tag时，偶尔会出现不同线程的时间戳相同的情况，用对象内存地址可以避免。