### PR TITLE
fix gpu memory explosion problem when bthread is used

### DIFF
--- a/core/predictor/common/macros.h
+++ b/core/predictor/common/macros.h
@@ -27,6 +27,10 @@ namespace predictor {
   }
 #endif
 
+#ifdef WITH_GPU
+#define USE_PTHREAD
+#endif
+
 #ifdef USE_PTHREAD
 
 #define THREAD_T pthread_t


### PR DESCRIPTION

after fixed:
- with memory optimization:
![image](https://user-images.githubusercontent.com/35550832/80000588-e6a75e80-84ef-11ea-84a7-40bb4fd04fcd.png)
- without memory optimization:
![image](https://user-images.githubusercontent.com/35550832/80000747-1c4c4780-84f0-11ea-9d70-502903cc124a.png)

