### PR TITLE
add inference model to serving model interface

### DIFF
--- a/doc/INFERNCE_TO_SERVING.md
+++ b/doc/INFERNCE_TO_SERVING.md
@@ -1,0 +1,14 @@
+# How to Convert Paddle Inference Model To Paddle Serving Format
+
+([简体中文](./INFERENCE_TO_SERVING_CN.md)|English)
+
+## Example
+
+``` python
+from paddle_serving_client.io import inference_model_to_serving
+inference_model_dir = "your_inference_model"
+serving_client_dir = "serving_client_dir"
+serving_server_dir = "serving_server_dir"
+feed_var_names, fetch_var_names = inference_model_to_serving(
+		inference_model_dir, serving_client_dir, serving_server_dir)
+```

--- a/doc/INFERNCE_TO_SERVING_CN.md
+++ b/doc/INFERNCE_TO_SERVING_CN.md
@@ -1,0 +1,14 @@
+# 如何从Paddle保存的预测模型转为Paddle Serving格式可部署的模型
+
+([English](./INFERENCE_TO_SERVING.md)|简体中文)
+
+## 示例
+
+``` python
+from paddle_serving_client.io import inference_model_to_serving
+inference_model_dir = "your_inference_model"
+serving_client_dir = "serving_client_dir"
+serving_server_dir = "serving_server_dir"
+feed_var_names, fetch_var_names = inference_model_to_serving(
+		inference_model_dir, serving_client_dir, serving_server_dir)
+```


### PR DESCRIPTION
when a user has a model saved from io.save_inference_model, he or she might need to transfer the model into servable format. This PR solves this problem.