### PR TITLE
add package module for paddle_serving_app

### DIFF
--- a/python/paddle_serving_app/__init__.py
+++ b/python/paddle_serving_app/__init__.py
@@ -15,3 +15,4 @@ from .reader.chinese_bert_reader import ChineseBertReader
 from .reader.image_reader import ImageReader
 from .reader.lac_reader import LACReader
 from .reader.senta_reader import SentaReader
+from .models.model_list import ServingModels

--- a/python/paddle_serving_app/models/__init__.py
+++ b/python/paddle_serving_app/models/__init__.py
@@ -11,8 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .reader.chinese_bert_reader import ChineseBertReader
-from .reader.image_reader import ImageReader
-from .reader.lac_reader import LACReader
-from .reader.senta_reader import SentaReader
-from .models import ServingModels
+
+from .model_list import ServingModels

--- a/python/paddle_serving_app/models/model_list.py
+++ b/python/paddle_serving_app/models/model_list.py
@@ -57,7 +57,7 @@ class ServingModels(object):
                 "resnet_v2_151_imagenet",
                 "resnet_v2_18_imagenet",
                 "resnet_v2_34_imagenet",
-                " resnet_v2_50_imagenet",
+                "resnet_v2_50_imagenet",
                 "resnext101_32x16d_wsl",
                 "resnext101_32x32d_wsl",
                 "resnext101_32x48d_wsl",

--- a/python/paddle_serving_app/package.py
+++ b/python/paddle_serving_app/package.py
@@ -15,7 +15,7 @@
 Usage:
     Download a package for serving directly
     Example:
-        python -m paddle_serving_app.models --get senta_bilstm
+        python -m paddle_serving_app.models --get_model senta_bilstm
         python -m paddle_serving_app.models --list_model
 """
 
@@ -26,9 +26,9 @@ from .models import ServingModels
 def parse_args():  # pylint: disable=doc-string-missing
     parser = argparse.ArgumentParser("serve")
     parser.add_argument(
-        "--get", type=str, default="", help="Download a specific model")
+        "--get_model", type=str, default="", help="Download a specific model")
     parser.add_argument(
-        "--list_model", type=bool, default="", help="List Models")
+        "--list_model", type=bool, default=False, help="List Models")
     return parser.parse_args()
 
 
@@ -39,10 +39,10 @@ if __name__ == "__main__":
         model_names = model_handle.get_model_list()
         for key in model_names:
             print(key)
-    elif args.get != "":
+    elif args.get_model != "":
         model_handle = ServingModels()
         model_names = model_handle.get_model_list()
-        if args.get not in model_names:
+        if args.get_model not in model_names:
             print(
                 "Your model name does not exist in current model list, stay tuned"
             )

--- a/python/paddle_serving_app/package.py
+++ b/python/paddle_serving_app/package.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
                 "Your model name does not exist in current model list, stay tuned"
             )
             sys.exit(0)
-        model_handle.download(args.get)
+        model_handle.download(args.get_model)
     else:
         print("Wrong argument")
         print("""

--- a/python/paddle_serving_app/package.py
+++ b/python/paddle_serving_app/package.py
@@ -28,13 +28,13 @@ def parse_args():  # pylint: disable=doc-string-missing
     parser.add_argument(
         "--get_model", type=str, default="", help="Download a specific model")
     parser.add_argument(
-        "--list_model", type=bool, default=False, help="List Models")
+        '--list_model', nargs='*', default=None, help="List Models")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    if args.list_model:
+    if args.list_model != None:
         model_handle = ServingModels()
         model_names = model_handle.get_model_list()
         for key in model_names:

--- a/python/paddle_serving_app/package.py
+++ b/python/paddle_serving_app/package.py
@@ -1,0 +1,60 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Usage:
+    Download a package for serving directly
+    Example:
+        python -m paddle_serving_app.models --get senta_bilstm
+        python -m paddle_serving_app.models --list_model
+"""
+
+import argparse
+from .models import ServingModels
+
+
+def parse_args():  # pylint: disable=doc-string-missing
+    parser = argparse.ArgumentParser("serve")
+    parser.add_argument(
+        "--get", type=str, default="", help="Download a specific model")
+    parser.add_argument(
+        "--list_model", type=bool, default="", help="List Models")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if args.list_model:
+        model_handle = ServingModels()
+        model_names = model_handle.get_model_list()
+        for key in model_names:
+            print(key)
+    elif args.get != "":
+        model_handle = ServingModels()
+        model_names = model_handle.get_model_list()
+        if args.get not in model_names:
+            print(
+                "Your model name does not exist in current model list, stay tuned"
+            )
+            sys.exit(0)
+        model_handle.download(args.get)
+    else:
+        print("Wrong argument")
+        print("""
+              Usage:
+              Download a package for serving directly
+              Example:
+                   python -m paddle_serving_app.models --get senta_bilstm
+                   python -m paddle_serving_app.models --list_model
+              """)
+        pass

--- a/python/setup.py.app.in
+++ b/python/setup.py.app.in
@@ -48,7 +48,8 @@ REQUIRED_PACKAGES = [
 packages=['paddle_serving_app',
           'paddle_serving_app.reader',
 	  'paddle_serving_app.utils',
-      'paddle_serving_app.reader.pddet']
+	  'paddle_serving_app.models',
+	  'paddle_serving_app.reader.pddet']
 
 package_data={}
 package_dir={'paddle_serving_app':
@@ -57,8 +58,10 @@ package_dir={'paddle_serving_app':
              '${PADDLE_SERVING_BINARY_DIR}/python/paddle_serving_app/reader',
 	     'paddle_serving_app.utils':
 	     '${PADDLE_SERVING_BINARY_DIR}/python/paddle_serving_app/utils',
-          'paddle_serving_app.reader.pddet':
-           '${PADDLE_SERVING_BINARY_DIR}/python/paddle_serving_app/reader/pddet',}
+	     'paddle_serving_app.models':
+	     '${PADDLE_SERVING_BINARY_DIR}/python/paddle_serving_app/models',
+	     'paddle_serving_app.reader.pddet':
+	     '${PADDLE_SERVING_BINARY_DIR}/python/paddle_serving_app/reader/pddet',}
 
 setup(
     name='paddle-serving-app',


### PR DESCRIPTION
When a user install paddle_serving_app, he or she can list all the pre-packaged models or download a servable package by name.
``` shell
python -m paddle_serving_app.package --list_model
python -m paddle_serving_app.package --get_model senta_bilstm
```