### PR TITLE
fix codestyle check

### DIFF
--- a/tools/serving_check_style.sh
+++ b/tools/serving_check_style.sh
@@ -23,6 +23,12 @@ function check_style() {
     pre-commit install
     clang-format --version
 
+    # virtualenv(20.0.19) was updated on May 3. The new version of virtualenv
+    # uses `sysconfig.get_makefile_filename`. But python2.7.5 does not support
+    # `sysconfig.get_makefile_filename`, only `sysconfig._get_makefile_filename`.
+    # See more: https://bugs.python.org/issue22199
+    pip install -U 'virtualenv==20.0.18'
+
     if ! pre-commit run -a ; then
         git diff
         exit 1


### PR DESCRIPTION
pre-commit使用的virtualenv在5月3日更新了[新版本](https://pypi.org/project/virtualenv/#files)，新版本的virtualenv使用了`sysconfig.get_makefile_filename` ，而Python2.7.5（CentOS7默认Python2版本）不支持`sysconfig.get_makefile_filename`，只支持`sysconfig._get_makefile_filename`，详见https://bugs.python.org/issue22199