### PR TITLE
optimize doc of Criteo CTR with Cube

### DIFF
--- a/python/examples/criteo_ctr_with_cube/README.md
+++ b/python/examples/criteo_ctr_with_cube/README.md
@@ -31,7 +31,9 @@ the model will be in ./ctr_server_model_kv and ./ctr_client_config.
 
 ### Start Sparse Parameter Indexing Service
 ```
-cp ../../../build_server/output/bin/cube* ./cube/
+wget https://paddle-serving.bj.bcebos.com/others/cube_app.tar.gz
+tar xf cube_app.tar.gz
+mv cube_app/cube* ./cube/
 sh cube_prepare.sh &
 ```
 

--- a/python/examples/criteo_ctr_with_cube/README_CN.md
+++ b/python/examples/criteo_ctr_with_cube/README_CN.md
@@ -29,7 +29,9 @@ mv models/data ./cube/
 
 ### 启动稀疏参数索引服务
 ```
-cp ../../../build_server/output/bin/cube* ./cube/
+wget https://paddle-serving.bj.bcebos.com/others/cube_app.tar.gz
+tar xf cube_app.tar.gz
+mv cube_app/cube* ./cube/
 sh cube_prepare.sh &
 ```
 


### PR DESCRIPTION
 http://newicafe.baidu.com/issue/DLTP-5368/show?from=page
为了尽量不让用户去编译Paddle Serving源码就可以用上Criteo CTR with Cube。
所有的Cube工具都被放置在一个压缩文件，存放于百度云BOS
用户下载之后就可以直接启动Cube

更改了相关中英文文档。