### PR TITLE
add mobilenet_cityspaces for image seg

### DIFF
--- a/python/paddle_serving_app/models/model_list.py
+++ b/python/paddle_serving_app/models/model_list.py
@@ -25,7 +25,9 @@ class ServingModels(object):
         self.model_dict["SemanticRepresentation"] = ["ernie_base"]
         self.model_dict["ChineseWordSegmentation"] = ["lac"]
         self.model_dict["ObjectDetection"] = ["faster_rcnn", "yolov3"]
-        self.model_dict["ImageSegmentation"] = ["unet", "deeplabv3"]
+        self.model_dict["ImageSegmentation"] = [
+            "unet", "deeplabv3", "mobilenet_cityspaces"
+        ]
         self.model_dict["ImageClassification"] = [
             "resnet_v2_50_imagenet", "mobilenet_v2_imagenet"
         ]


### PR DESCRIPTION
向Paddle Serving App添加图像分割模型 mobilenet_cityspaces

步骤
1. 编译app包并安装
2. 
```
python -m paddle_serving_app.package --get_model mobilenet_cityspaces
tar xf mobilenet_cityspaces.tar.gz
python -m paddle_serving_server_gpu.serve --model seg_server_conf --port 9393
python seg_client.py seg_client_conf/serving_client_conf.prototxt munster_000036_000019_leftImg8bit.png
```