### PR TITLE
[WIP]add inner port

### DIFF
--- a/python/paddle_serving_server/serve.py
+++ b/python/paddle_serving_server/serve.py
@@ -58,6 +58,11 @@ def parse_args():  # pylint: disable=doc-string-missing
         default=False,
         action="store_true",
         help="Use Multi-language-service")
+    parser.add_argument(
+        "--inner_port",
+        default=12000,
+        type=int,
+        help="Starting port for rpc service")
     return parser.parse_args()
 
 
@@ -116,7 +121,10 @@ if __name__ == "__main__":
         service = WebService(name=args.name)
         service.load_model_config(args.model)
         service.prepare_server(
-            workdir=args.workdir, port=args.port, device=args.device)
+            workdir=args.workdir,
+            port=args.port,
+            inner_port=args.inner_port,
+            device=args.device)
         service.run_rpc_service()
 
         app_instance = Flask(__name__)

--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -60,13 +60,14 @@ class WebService(object):
     def prepare_server(self,
                        workdir="",
                        port=9393,
+                       inner_port=12000,
                        device="cpu",
                        mem_optim=True,
                        ir_optim=False):
         self.workdir = workdir
         self.port = port
         self.device = device
-        default_port = 12000
+        default_port = inner_port
         self.port_list = []
         self.mem_optim = mem_optim
         self.ir_optim = ir_optim

--- a/python/paddle_serving_server_gpu/__init__.py
+++ b/python/paddle_serving_server_gpu/__init__.py
@@ -73,6 +73,11 @@ def serve_args():
         default=False,
         action="store_true",
         help="Use Multi-language-service")
+    parser.add_argument(
+        "--inner_port",
+        type=int,
+        default=12000,
+        help="Starting port of rpc service")
     return parser.parse_args()
 
 

--- a/python/paddle_serving_server_gpu/serve.py
+++ b/python/paddle_serving_server_gpu/serve.py
@@ -121,7 +121,10 @@ if __name__ == "__main__":
         if len(gpu_ids) > 0:
             web_service.set_gpus(gpu_ids)
         web_service.prepare_server(
-            workdir=args.workdir, port=args.port, device=args.device)
+            workdir=args.workdir,
+            port=args.port,
+            inner_port=args.inner_port,
+            device=args.device)
         web_service.run_rpc_service()
 
         app_instance = Flask(__name__)

--- a/python/paddle_serving_server_gpu/web_service.py
+++ b/python/paddle_serving_server_gpu/web_service.py
@@ -85,6 +85,7 @@ class WebService(object):
                        workdir="",
                        port=9393,
                        device="gpu",
+                       inner_port=12000,
                        gpuid=0,
                        mem_optim=True,
                        ir_optim=False):
@@ -93,7 +94,7 @@ class WebService(object):
         self.device = device
         self.gpuid = gpuid
         self.port_list = []
-        default_port = 12000
+        default_port = inner_port
         for i in range(1000):
             if self.port_is_available(default_port + i):
                 self.port_list.append(default_port + i)


### PR DESCRIPTION
添加inner_port接口设置http模式中使用的rpc端口
后续版本中可能会废弃这种模式，暂不合入
示例
```
 python -m paddle_serving_server_gpu.serve --model uci_housing_model --thread 10 --port 9393 --name uci --inner_port 30000 --gpu_ids 0
```