### PR TITLE
fixed opencv version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.12, <=1.16.4 ; python_version<"3.5"
+opencv-python==4.2.0.32
 google>=2.0.3
 protobuf>=3.12.2
 grpcio-tools>=1.28.1


### PR DESCRIPTION
opencv的python包前段时间更新，新版本不兼容旧版本。固定版本以通过ci