### PR TITLE
Threaded Flask for local predictor

### DIFF
--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -56,7 +56,8 @@ class WebService(object):
         from .proto import general_model_config_pb2 as m_config
         import google.protobuf.text_format
         if os.path.isdir(model_config):
-            client_config = "{}/serving_server_conf.prototxt".format(model_config)
+            client_config = "{}/serving_server_conf.prototxt".format(
+                model_config)
         elif os.path.isfile(path):
             client_config = model_config
         model_conf = m_config.GeneralModelConfig()
@@ -192,9 +193,7 @@ class WebService(object):
 
     def run_web_service(self):
         print("This API will be deprecated later. Please do not use it")
-        self.app_instance.run(host="0.0.0.0",
-                              port=self.port,
-                              threaded=True)
+        self.app_instance.run(host="0.0.0.0", port=self.port, threaded=True)
 
     def get_app_instance(self):
         return self.app_instance

--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -52,6 +52,19 @@ class WebService(object):
     def load_model_config(self, model_config):
         print("This API will be deprecated later. Please do not use it")
         self.model_config = model_config
+        import os
+        from .proto import general_model_config_pb2 as m_config
+        import google.protobuf.text_format
+        if os.path.isdir(model_config):
+            client_config = "{}/serving_server_conf.prototxt".format(model_config)
+        elif os.path.isfile(path):
+            client_config = model_config
+        model_conf = m_config.GeneralModelConfig()
+        f = open(client_config, 'r')
+        model_conf = google.protobuf.text_format.Merge(
+            str(f.read()), model_conf)
+        self.feed_names = [var.alias_name for var in model_conf.feed_var]
+        self.fetch_names = [var.alias_name for var in model_conf.fetch_var]
 
     def _launch_rpc_service(self):
         op_maker = OpMaker()
@@ -181,8 +194,7 @@ class WebService(object):
         print("This API will be deprecated later. Please do not use it")
         self.app_instance.run(host="0.0.0.0",
                               port=self.port,
-                              threaded=False,
-                              processes=1)
+                              threaded=True)
 
     def get_app_instance(self):
         return self.app_instance

--- a/python/paddle_serving_server_gpu/web_service.py
+++ b/python/paddle_serving_server_gpu/web_service.py
@@ -58,6 +58,19 @@ class WebService(object):
     def load_model_config(self, model_config):
         print("This API will be deprecated later. Please do not use it")
         self.model_config = model_config
+        import os
+        from .proto import general_model_config_pb2 as m_config
+        import google.protobuf.text_format
+        if os.path.isdir(model_config):
+            client_config = "{}/serving_server_conf.prototxt".format(model_config)
+        elif os.path.isfile(path):
+            client_config = model_config
+        model_conf = m_config.GeneralModelConfig()
+        f = open(client_config, 'r')
+        model_conf = google.protobuf.text_format.Merge(
+            str(f.read()), model_conf)
+        self.feed_names = [var.alias_name for var in model_conf.feed_var]
+        self.fetch_names = [var.alias_name for var in model_conf.fetch_var]
 
     def set_gpus(self, gpus):
         print("This API will be deprecated later. Please do not use it")
@@ -242,8 +255,7 @@ class WebService(object):
         print("This API will be deprecated later. Please do not use it")
         self.app_instance.run(host="0.0.0.0",
                               port=self.port,
-                              threaded=False,
-                              processes=4)
+                              threaded=True)
 
     def get_app_instance(self):
         return self.app_instance

--- a/python/paddle_serving_server_gpu/web_service.py
+++ b/python/paddle_serving_server_gpu/web_service.py
@@ -62,7 +62,8 @@ class WebService(object):
         from .proto import general_model_config_pb2 as m_config
         import google.protobuf.text_format
         if os.path.isdir(model_config):
-            client_config = "{}/serving_server_conf.prototxt".format(model_config)
+            client_config = "{}/serving_server_conf.prototxt".format(
+                model_config)
         elif os.path.isfile(path):
             client_config = model_config
         model_conf = m_config.GeneralModelConfig()
@@ -253,9 +254,7 @@ class WebService(object):
 
     def run_web_service(self):
         print("This API will be deprecated later. Please do not use it")
-        self.app_instance.run(host="0.0.0.0",
-                              port=self.port,
-                              threaded=True)
+        self.app_instance.run(host="0.0.0.0", port=self.port, threaded=True)
 
     def get_app_instance(self):
         return self.app_instance


### PR DESCRIPTION
## PR Type
othres

## Description
修复CUDA3 ERROR在local predictor模式，把process改成了thread
在load-model-config函数当中增加了对prototxt的解析，确保rpc和local predictor模式下都可以执行对应的api提前获取到feed和fetch vars