### PR TITLE
Update paddle predictor API verson to 2.0

### DIFF
--- a/python/examples/pipeline/ocr/web_service.py
+++ b/python/examples/pipeline/ocr/web_service.py
@@ -48,7 +48,7 @@ class DetOp(Op):
         imgs = []
         for key in input_dict.keys():
             data = base64.b64decode(input_dict[key].encode('utf8'))
-            data = np.fromstring(data, np.uint8)
+            data = np.frombuffer(data, np.uint8)
             self.im = cv2.imdecode(data, cv2.IMREAD_COLOR)
             self.ori_h, self.ori_w, _ = self.im.shape
             det_img = self.det_preprocess(self.im)
@@ -57,7 +57,7 @@ class DetOp(Op):
         return {"image": np.concatenate(imgs, axis=0)}, False, None, ""
 
     def postprocess(self, input_dicts, fetch_dict, log_id):
-#        print(fetch_dict)
+        #        print(fetch_dict)
         det_out = fetch_dict["concat_1.tmp_0"]
         ratio_list = [
             float(self.new_h) / self.ori_h, float(self.new_w) / self.ori_w
@@ -114,5 +114,5 @@ class OcrService(WebService):
 
 
 uci_service = OcrService(name="ocr")
-uci_service.prepare_pipeline_config("config2.yml")
+uci_service.prepare_pipeline_config("config.yml")
 uci_service.run_service()

--- a/python/examples/pipeline/simple_web_service/web_service.py
+++ b/python/examples/pipeline/simple_web_service/web_service.py
@@ -14,7 +14,7 @@
 try:
     from paddle_serving_server.web_service import WebService, Op
 except ImportError:
-    from paddle_serving_server.web_service import WebService, Op
+    from paddle_serving_server_gpu.web_service import WebService, Op
 import logging
 import numpy as np
 import sys
@@ -34,8 +34,11 @@ class UciOp(Op):
         x_value = input_dict["x"].split(self.batch_separator)
         x_lst = []
         for x_val in x_value:
-            x_lst.append(np.array([float(x.strip()) for x in x_val.split(self.separator)]).reshape(1, 13))
-        input_dict["x"] = np.concatenate(x_lst, axis=0) 
+            x_lst.append(
+                np.array([
+                    float(x.strip()) for x in x_val.split(self.separator)
+                ]).reshape(1, 13))
+        input_dict["x"] = np.concatenate(x_lst, axis=0)
         proc_dict = {}
         return input_dict, False, None, ""
 
@@ -53,5 +56,5 @@ class UciService(WebService):
 
 
 uci_service = UciService(name="uci")
-uci_service.prepare_pipeline_config("config2.yml")
+uci_service.prepare_pipeline_config("config.yml")
 uci_service.run_service()


### PR DESCRIPTION
1.更换paddle_serving_app/local_predict.py 本地推理接口使用的Paddle API版本
2.修改函数注释，增加部分功能注释，删除无用变量
3.修改examples/pipeline下 示例中Import问题
