### PR TITLE
fix little bug on localWebService

### DIFF
--- a/python/examples/ocr/ocr_debugger_server.py
+++ b/python/examples/ocr/ocr_debugger_server.py
@@ -106,7 +106,7 @@ ocr_service.load_model_config("ocr_rec_model")
 ocr_service.prepare_server(workdir="workdir", port=9292)
 ocr_service.init_det_debugger(det_model_config="ocr_det_model")
 if sys.argv[1] == 'gpu':
-    ocr_service.set_gpus("2")
+    ocr_service.set_gpus("0")
     ocr_service.run_debugger_service(gpu=True)
 elif sys.argv[1] == 'cpu':
     ocr_service.run_debugger_service()

--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -267,6 +267,10 @@ class WebService(object):
         from paddle_serving_app.local_predict import LocalPredictor
         self.client = LocalPredictor()
         if gpu:
+            # if user forget to call function `set_gpus` to set self.gpus.
+            # default self.gpus = [0].
+            if len(self.gpus) == 0:
+                self.gpus.append(0)
             self.client.load_model_config(
                 "{}".format(self.model_config), use_gpu=True, gpu_id=self.gpus[0])
         else:


### PR DESCRIPTION
1、修改了ocr示例中默认使用gpu_id=2，用户若无意识，gpu小于2时，可能导致错误。
2、修改了web_service.py中，若用户忘记调用set_gpus函数，导致的错误。
以上两处均属于使用性问题，修改后，对用户更友好。