### PR TITLE
Update ipipe_py3.sh

### DIFF
--- a/tools/scripts/ipipe_py3.sh
+++ b/tools/scripts/ipipe_py3.sh
@@ -148,7 +148,7 @@ function before_hook() {
     setproxy
     unsetproxy
     cd ${build_path}/python
-    python3.6 -m pip install --upgrade pip
+    python3.6 -m pip install --upgrade pip==20.0.1
     python3.6 -m pip install requests
     python3.6 -m pip install -r requirements.txt -i https://mirror.baidu.com/pypi/simple
     python3.6 -m pip install numpy==1.16.4


### PR DESCRIPTION
pip21.1版本安装python依赖包会报错，固定升级到稳定的21.0.1版本