### PR TITLE
修复tools/generate_runtime_docker.sh的BUG

### DIFF
--- a/tools/generate_runtime_docker.sh
+++ b/tools/generate_runtime_docker.sh
@@ -66,6 +66,8 @@ function run
       base_image="nvidia\/cuda:10.1-cudnn7-runtime-ubuntu16.04"
   elif [ $env == "cuda10.2" ]; then
       base_image="nvidia\/cuda:10.2-cudnn8-runtime-ubuntu16.04"
+  elif [ $env == "cuda11" ]; then
+      base_image="nvidia\/cuda:11.3.0-cudnn8-runtime-ubuntu18.04"
   fi
   echo "base image: $base_image"
   echo "named arg: python: $python"


### PR DESCRIPTION
在用sh ./tools/generate_runtime_docker.sh --env cuda11生成runtime镜像时发生错误，经过查找原因，是脚本中run函数中没有“cuda11”的逻辑判断和基础镜像设置。