### PR TITLE
fix local bug and gpuids bug

### DIFF
--- a/python/paddle_serving_server/serve.py
+++ b/python/paddle_serving_server/serve.py
@@ -263,10 +263,8 @@ def start_multi_card(args, serving_port=None):  # pylint: disable=doc-string-mis
         if "CUDA_VISIBLE_DEVICES" in os.environ:
             env_gpus = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
             for ids in gpus:
-                if int(ids) >= len(env_gpus):
-                    print(
-                        " Max index of gpu_ids out of range, the number of CUDA_VISIBLE_DEVICES is {}."
-                        .format(len(env_gpus)))
+                if ids not in env_gpus:
+                    print("gpu_ids is not in CUDA_VISIBLE_DEVICES.")
                     exit(-1)
         else:
             env_gpus = []


### PR DESCRIPTION
1、修复了prepare_server阶段不该引入workdir下的rpc配置问题。
此时，即使使用local_predictor也会创建workdir，一系列的workflow等配置，而不使用rpc根本不需要。
2、修复了gpuid 必须<len(cuda_device)的bug，不符合认知。
例如我配置了cuda_device = 3，但是gpuid 必须是0.
cuda_device_list = cuda_device.split(',')
原因是判断条件为gpuid < len(cuda_device_list)

然而这次OCR使用Windows报错的根本原因是，因为我们代码中（pipeline、pd-server client app、C++）大量使用了linux中的一些脚本命令，在windows中没有。
建议：目前先这样，优先解决性能本质问题，后续做差不多了，再支持windows。
