### PR TITLE
fix gpuid and device and timeout

### DIFF
--- a/core/predictor/framework/infer.cpp
+++ b/core/predictor/framework/infer.cpp
@@ -391,7 +391,8 @@ int InferManager::proc_initialize(const char* path,
     return -1;
   }
   uint32_t engine_num = model_toolkit_conf.engines_size();
-  im::bsf::TaskExecutorVector<TaskT>::instance().resize(*engine_index_ptr+engine_num);
+  im::bsf::TaskExecutorVector<TaskT>::instance().resize(*engine_index_ptr +
+                                                        engine_num);
   for (uint32_t ei = 0; ei < engine_num; ++ei) {
     LOG(INFO) << "model_toolkit_conf.engines(" << ei
               << ").name: " << model_toolkit_conf.engines(ei).name();

--- a/python/paddle_serving_client/client.py
+++ b/python/paddle_serving_client/client.py
@@ -79,7 +79,7 @@ class SDKConfig(object):
         self.tag_list = []
         self.cluster_list = []
         self.variant_weight_list = []
-        self.rpc_timeout_ms = 20000
+        self.rpc_timeout_ms = 200000
         self.load_balance_strategy = "la"
 
     def add_server_variant(self, tag, cluster, variant_weight):
@@ -142,7 +142,7 @@ class Client(object):
         self.profile_ = _Profiler()
         self.all_numpy_input = True
         self.has_numpy_input = False
-        self.rpc_timeout_ms = 20000
+        self.rpc_timeout_ms = 200000
         from .serving_client import PredictorRes
         self.predictorres_constructor = PredictorRes
 

--- a/python/paddle_serving_server/serve.py
+++ b/python/paddle_serving_server/serve.py
@@ -31,6 +31,67 @@ elif sys.version_info.major == 3:
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
+def format_gpu_to_strlist(unformatted_gpus):
+    gpus_strlist = []
+    if isinstance(unformatted_gpus, int):
+        gpus_strlist = [str(unformatted_gpus)]
+    elif isinstance(unformatted_gpus, list):
+        if unformatted_gpus == [""]:
+            gpus_strlist = ["-1"]
+        elif len(unformatted_gpus) == 0:
+            gpus_strlist = ["-1"]
+        else:
+            gpus_strlist = [str(x) for x in unformatted_gpus]
+    elif isinstance(unformatted_gpus, str):
+        if unformatted_gpus == "":
+            gpus_strlist = ["-1"]
+        else:
+            gpus_strlist = [unformatted_gpus]
+    elif unformatted_gpus == None:
+        gpus_strlist = ["-1"]
+    else:
+        raise ValueError("error input of set_gpus")
+
+    # check cuda visible
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        env_gpus = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+        for op_gpus_str in gpus_strlist:
+            op_gpu_list = op_gpus_str.split(",")
+            # op_gpu_list == ["-1"] means this op use CPU
+            # so don`t check cudavisible.
+            if op_gpu_list == ["-1"]:
+                continue
+            for ids in op_gpu_list:
+                if ids not in env_gpus:
+                    print("gpu_ids is not in CUDA_VISIBLE_DEVICES.")
+                    exit(-1)
+
+    # check gpuid is valid
+    for op_gpus_str in gpus_strlist:
+        op_gpu_list = op_gpus_str.split(",")
+        use_gpu = False
+        for ids in op_gpu_list:
+            if int(ids) < -1:
+                raise ValueError("The input of gpuid error.")
+            if int(ids) >= 0:
+                use_gpu = True
+            if int(ids) == -1 and use_gpu:
+                raise ValueError("You can not use CPU and GPU in one model.")
+
+    return gpus_strlist
+
+
+def is_gpu_mode(unformatted_gpus):
+    gpus_strlist = format_gpu_to_strlist(unformatted_gpus)
+    for op_gpus_str in gpus_strlist:
+        op_gpu_list = op_gpus_str.split(",")
+        for ids in op_gpu_list:
+            if int(ids) >= 0:
+                return True
+
+    return False
+
+
 def serve_args():
     parser = argparse.ArgumentParser("serve")
     parser.add_argument(
@@ -211,34 +272,15 @@ def start_gpu_card_model(gpu_mode, port, args):  # pylint: disable=doc-string-mi
 
 
 def start_multi_card(args, serving_port=None):  # pylint: disable=doc-string-missing
-    gpus = []
+
     if serving_port == None:
         serving_port = args.port
-
-    if args.gpu_ids == "":
-        gpus = []
-    else:
-        #check the gpu_id is valid or not.
-        gpus = args.gpu_ids
-        if isinstance(gpus, str):
-            gpus = [gpus]
-        if "CUDA_VISIBLE_DEVICES" in os.environ:
-            env_gpus = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
-            for op_gpus_str in gpus:
-                op_gpu_list = op_gpus_str.split(",")
-                for ids in op_gpu_list:
-                    if ids not in env_gpus:
-                        print("gpu_ids is not in CUDA_VISIBLE_DEVICES.")
-                        exit(-1)
 
     if args.use_lite:
         print("run using paddle-lite.")
         start_gpu_card_model(False, serving_port, args)
-    elif len(gpus) <= 0:
-        print("gpu_ids not set, going to run cpu service.")
-        start_gpu_card_model(False, serving_port, args)
     else:
-        start_gpu_card_model(True, serving_port, args)
+        start_gpu_card_model(is_gpu_mode(args.gpu_ids), serving_port, args)
 
 
 class MainService(BaseHTTPRequestHandler):
@@ -320,7 +362,9 @@ class MainService(BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-
+    # args.device is not used at all.
+    # just keep the interface.
+    # so --device should not be recommended at the HomePage.
     args = serve_args()
     for single_model_config in args.model:
         if os.path.isdir(single_model_config):
@@ -346,29 +390,10 @@ if __name__ == "__main__":
         web_service = WebService(name=args.name)
         web_service.load_model_config(args.model)
 
-        if args.gpu_ids == "":
-            gpus = []
-        else:
-            #check the gpu_id is valid or not.
-            gpus = args.gpu_ids
-            if isinstance(gpus, str):
-                gpus = [gpus]
-            if "CUDA_VISIBLE_DEVICES" in os.environ:
-                env_gpus = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
-                for op_gpus_str in gpus:
-                    op_gpu_list = op_gpus_str.split(",")
-                    for ids in op_gpu_list:
-                        if ids not in env_gpus:
-                            print("gpu_ids is not in CUDA_VISIBLE_DEVICES.")
-                            exit(-1)
-
-        if len(gpus) > 0:
-            web_service.set_gpus(gpus)
         workdir = "{}_{}".format(args.workdir, args.port)
         web_service.prepare_server(
             workdir=workdir,
             port=args.port,
-            device=args.device,
             use_lite=args.use_lite,
             use_xpu=args.use_xpu,
             ir_optim=args.ir_optim,
@@ -378,7 +403,8 @@ if __name__ == "__main__":
             use_trt=args.use_trt,
             gpu_multi_stream=args.gpu_multi_stream,
             op_num=args.op_num,
-            op_max_batch=args.op_max_batch)
+            op_max_batch=args.op_max_batch,
+            gpuid=args.gpu_ids)
         web_service.run_rpc_service()
 
         app_instance = Flask(__name__)

--- a/python/paddle_serving_server/serve.py
+++ b/python/paddle_serving_server/serve.py
@@ -99,7 +99,7 @@ def serve_args():
     parser.add_argument(
         "--port", type=int, default=9292, help="Port of the starting gpu")
     parser.add_argument(
-        "--device", type=str, default="gpu", help="Type of device")
+        "--device", type=str, default="cpu", help="Type of device")
     parser.add_argument(
         "--gpu_ids", type=str, default="", nargs="+", help="gpu ids")
     parser.add_argument(
@@ -179,9 +179,9 @@ def serve_args():
 
 def start_gpu_card_model(gpu_mode, port, args):  # pylint: disable=doc-string-missing
 
-    device = "gpu"
-    if gpu_mode == False:
-        device = "cpu"
+    device = "cpu"
+    if gpu_mode == True:
+        device = "gpu"
 
     thread_num = args.thread
     model = args.model

--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -26,6 +26,7 @@ import numpy as np
 import os
 from paddle_serving_server import pipeline
 from paddle_serving_server.pipeline import Op
+from paddle_serving_server.serve import format_gpu_to_strlist
 
 
 def port_is_available(port):
@@ -44,7 +45,7 @@ class WebService(object):
         # pipeline
         self._server = pipeline.PipelineServer(self.name)
 
-        self.gpus = []  # deprecated
+        self.gpus = ["-1"]  # deprecated
         self.rpc_service_list = []  # deprecated
 
     def get_pipeline_response(self, read_op):
@@ -103,19 +104,24 @@ class WebService(object):
         if client_config_path == None:
             self.client_config_path = file_path_list
 
+    # after this function, self.gpus should be a list of str or [].
     def set_gpus(self, gpus):
         print("This API will be deprecated later. Please do not use it")
-        if isinstance(gpus, int):
-            self.gpus = str(gpus)
-        elif isinstance(gpus, list):
-            self.gpus = [str(x) for x in gpus]
-        else:
-            self.gpus = gpus
+        self.gpus = format_gpu_to_strlist(gpus)
+
+# this function can be called by user
+# or by Function create_rpc_config
+# if by user, user can set_gpus or pass the `gpus`
+# if `gpus` == None, which means it`s not set at all.
+# at this time, we should use self.gpus instead.
+# otherwise, we should use the `gpus` first.
+# which means if set_gpus and `gpus` is both set.
+# `gpus` will be used.
 
     def default_rpc_service(self,
                             workdir,
                             port=9292,
-                            gpus=-1,
+                            gpus=None,
                             thread_num=2,
                             mem_optim=True,
                             use_lite=False,
@@ -127,16 +133,23 @@ class WebService(object):
                             gpu_multi_stream=False,
                             op_num=None,
                             op_max_batch=None):
+
         device = "gpu"
         server = Server()
+        # only when `gpus == None`, which means it`s not set at all
+        # we will use the self.gpus.
+        if gpus == None:
+            gpus = self.gpus
 
-        if gpus == -1 or gpus == "-1":
+        gpus = format_gpu_to_strlist(gpus)
+        server.set_gpuid(gpus)
+
+        if len(gpus) == 0 or gpus == ["-1"]:
             if use_lite:
                 device = "arm"
             else:
                 device = "cpu"
-        else:
-            server.set_gpuid(gpus)
+
         op_maker = OpMaker()
         op_seq_maker = OpSeqMaker()
 
@@ -190,40 +203,26 @@ class WebService(object):
     def _launch_rpc_service(self, service_idx):
         self.rpc_service_list[service_idx].run_server()
 
+    # if use this function, self.gpus must be set before.
+    # if not, we will use the default value, self.gpus = ["-1"].
+    # so we always pass the `gpus` = self.gpus. 
     def create_rpc_config(self):
-        if len(self.gpus) == 0:
-            # init cpu service
-            self.rpc_service_list.append(
-                self.default_rpc_service(
-                    self.workdir,
-                    self.port_list[0],
-                    -1,
-                    thread_num=self.thread_num,
-                    mem_optim=self.mem_optim,
-                    use_lite=self.use_lite,
-                    use_xpu=self.use_xpu,
-                    ir_optim=self.ir_optim,
-                    precision=self.precision,
-                    use_calib=self.use_calib,
-                    op_num=self.op_num,
-                    op_max_batch=self.op_max_batch))
-        else:
-            self.rpc_service_list.append(
-                self.default_rpc_service(
-                    self.workdir,
-                    self.port_list[0],
-                    self.gpus,
-                    thread_num=self.thread_num,
-                    mem_optim=self.mem_optim,
-                    use_lite=self.use_lite,
-                    use_xpu=self.use_xpu,
-                    ir_optim=self.ir_optim,
-                    precision=self.precision,
-                    use_calib=self.use_calib,
-                    use_trt=self.use_trt,
-                    gpu_multi_stream=self.gpu_multi_stream,
-                    op_num=self.op_num,
-                    op_max_batch=self.op_max_batch))
+        self.rpc_service_list.append(
+            self.default_rpc_service(
+                self.workdir,
+                self.port_list[0],
+                self.gpus,
+                thread_num=self.thread_num,
+                mem_optim=self.mem_optim,
+                use_lite=self.use_lite,
+                use_xpu=self.use_xpu,
+                ir_optim=self.ir_optim,
+                precision=self.precision,
+                use_calib=self.use_calib,
+                use_trt=self.use_trt,
+                gpu_multi_stream=self.gpu_multi_stream,
+                op_num=self.op_num,
+                op_max_batch=self.op_max_batch))
 
     def prepare_server(self,
                        workdir,
@@ -240,12 +239,13 @@ class WebService(object):
                        gpu_multi_stream=False,
                        op_num=None,
                        op_max_batch=None,
-                       gpuid=-1):
+                       gpuid=None):
         print("This API will be deprecated later. Please do not use it")
         self.workdir = workdir
         self.port = port
         self.thread_num = thread_num
-        self.device = device
+        # self.device is not used at all.
+        # device is set by gpuid.
         self.precision = precision
         self.use_calib = use_calib
         self.use_lite = use_lite
@@ -257,12 +257,14 @@ class WebService(object):
         self.gpu_multi_stream = gpu_multi_stream
         self.op_num = op_num
         self.op_max_batch = op_max_batch
-        if isinstance(gpuid, int):
-            self.gpus = str(gpuid)
-        elif isinstance(gpuid, list):
-            self.gpus = [str(x) for x in gpuid]
+
+        # if gpuid != None, we will use gpuid first.
+        # otherwise, keep the self.gpus unchanged.
+        # maybe self.gpus is set by the Function set_gpus.
+        if gpuid != None:
+            self.gpus = format_gpu_to_strlist(gpuid)
         else:
-            self.gpus = gpuid
+            pass
 
         default_port = 12000
         for i in range(1000):
@@ -359,8 +361,8 @@ class WebService(object):
         if gpu:
             # if user forget to call function `set_gpus` to set self.gpus.
             # default self.gpus = [0].
-            if len(self.gpus) == 0:
-                self.gpus.append(0)
+            if len(self.gpus) == 0 or self.gpus == ["-1"]:
+                self.gpus = ["0"]
             # right now, local Predictor only support 1 card.
             # no matter how many gpu_id is in gpus, we only use the first one.
             gpu_id = (self.gpus[0].split(","))[0]

--- a/python/paddle_serving_server/web_service.py
+++ b/python/paddle_serving_server/web_service.py
@@ -134,7 +134,7 @@ class WebService(object):
                             op_num=None,
                             op_max_batch=None):
 
-        device = "gpu"
+        device = "cpu"
         server = Server()
         # only when `gpus == None`, which means it`s not set at all
         # we will use the self.gpus.
@@ -149,6 +149,8 @@ class WebService(object):
                 device = "arm"
             else:
                 device = "cpu"
+        else:
+            device = "gpu"
 
         op_maker = OpMaker()
         op_seq_maker = OpSeqMaker()
@@ -227,7 +229,7 @@ class WebService(object):
     def prepare_server(self,
                        workdir,
                        port=9393,
-                       device="gpu",
+                       device="cpu",
                        precision="fp32",
                        use_calib=False,
                        use_lite=False,


### PR DESCRIPTION
1、统一将gpuid的类型修改写成一个函数，统一处理并判断是否有异常设置。
2、修改device的设置
3、修改timeout设置，机器好坏情况不定，可能导致timeout
4、增加部分注释。

其中关于device字段和gpuid字段逻辑如下：
由于以前的示例有用set_gpuid，也有直接prepare_server传，prepare_server中gpuid字段有默认值，导致相互冲突覆盖。
此次改动基本的逻辑如下：
1、prepare_server中gpuid字段默认值改为None，当gpuid== None，我们认为是用户没传该参数（一般用户不会专门把它写成None，如果有，我们也认为该字段不是一个合法的gpuid，我们也认为等于没传合法参数），所以此时使用self.gpuid
self.gpuid 此时，可能是默认值，也可能用户已经调用了set_gpuid。
所以，当prepare_server中gpuid == None时，我们使用self.gpuid 
而，当prepare_server中gpuid字段不是None时，我们使用prepare_server中的gpuid字段。

gpu_ids 现在是一个str[],为了支持多模型，每个模型多卡，例如模型A和模型B， --gpu_ids 0,1   1,2，每一个都是一个str.
例如，模型A对应着"0,1".这个会最终写到model_toolkit中。

2、device参数类似的逻辑。其中device部分主要由函数接口传参指定或根据gpuid来确定。
目前--device参数已经没有用了，建议在主页中不再介绍该参数。
如果想使用cpu, 直接不传--gpu_ids或者--gpu_ids -1即可。
