### PR TITLE
Modify model conversion interfaces and model load methods

### DIFF
--- a/python/pipeline/pipeline_client.py
+++ b/python/pipeline/pipeline_client.py
@@ -93,13 +93,19 @@ class PipelineClient(object):
     def _unpack_response_package(self, resp, fetch):
         return resp
 
-    def predict(self, feed_dict, fetch=None, asyn=False, profile=False):
+    def predict(self,
+                feed_dict,
+                fetch=None,
+                asyn=False,
+                profile=False,
+                log_id=0):
         if not isinstance(feed_dict, dict):
             raise TypeError(
                 "feed must be dict type with format: {name: value}.")
         if fetch is not None and not isinstance(fetch, list):
             raise TypeError("fetch must be list type with format: [name].")
         req = self._pack_request_package(feed_dict, profile)
+        req.logid = log_id
         if not asyn:
             resp = self._stub.inference(req)
             return self._unpack_response_package(resp, fetch)

--- a/python/pipeline/util.py
+++ b/python/pipeline/util.py
@@ -39,7 +39,7 @@ class AvailablePortGenerator(object):
     def port_is_available(port):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             sock.settimeout(2)
-            result = sock.connect_ex(('127.0.0.1', port))
+            result = sock.connect_ex(('0.0.0.0', port))
         if result != 0:
             return True
         else:


### PR DESCRIPTION
1. 修改非加密模型转换接口，不使用save_inference_model做模型转换，因该接口会加入sacle op导致fetch结果与导出的prototxt结构不一致。不强制将模型名称改成__params__和__model__，只生成prototxt文件。

- *.pdiparams + *.pdmodel 同时存在时，serving_server目录下模型名称保持不变，仍为*.pdiparams 和 *.pdmodel 。
- __model__ + __params__同时存在时，serving_server目录下模型名称保持不变，仍为 __model__ 和 __params__。
- __model__ + 散列参数文件时，serving_server目录下模型名称为*.pdiparams 和 *.pdmodel，此时的fetch名称与之前可能不同

2.修复Pipeline Local_predict模式中predictor获取推理结果异常的bug。当有多个fetch结果且使用save_inference_model做模型转换时，此处的结果顺序有问题。

3.Pipeline_client接口中增加『pipeline_grpc』的交互模式，提供Pipeline 之间的网络交互，如多机分布式训练（MP + PP)的模型可以使用此模式。

4.修改Pipeline的Op::process函数，增加入参和返回结果，以便于异常时的问题记录