### PR TITLE
fix bug: client core while low version server do not have profile_time

### DIFF
--- a/core/general-client/src/brpc_client.cpp
+++ b/core/general-client/src/brpc_client.cpp
@@ -184,10 +184,12 @@ int ServingBrpcClient::predict(const PredictorInputs& inputs,
       oss << "op" << i << "=" << t << "ms,";
     }
   }
-  int i = op_num - 1;
-  double server_cost = (res.profile_time(i * 2 + 1)
-               - res.profile_time(i * 2)) / 1000.0;
-  oss << "server_cost=" << server_cost << "ms.";
+  if (op_num > 0) {
+    int i = op_num - 1;
+    double server_cost = (res.profile_time(i * 2 + 1)
+                 - res.profile_time(i * 2)) / 1000.0;
+    oss << "server_cost=" << server_cost << "ms.";
+  }
   LOG(INFO) << oss.str();
 
   return 0;

--- a/core/general-client/src/general_model.cpp
+++ b/core/general-client/src/general_model.cpp
@@ -449,10 +449,12 @@ int PredictorClient::numpy_predict(
       oss << "op" << i << "=" << t << "ms,";
     }
   }
-  int i = op_num - 1;
-  double server_cost = (res.profile_time(i * 2 + 1)
-               - res.profile_time(i * 2)) / 1000.0;
-  oss << "server_cost=" << server_cost << "ms.";
+  if (op_num > 0) {
+    int i = op_num - 1;
+    double server_cost = (res.profile_time(i * 2 + 1)
+                 - res.profile_time(i * 2)) / 1000.0;
+    oss << "server_cost=" << server_cost << "ms.";
+  }
   LOG(INFO) << oss.str();
   return 0;
 }


### PR DESCRIPTION
1. 高版本client请求低版本server时，由于server返回值不带有profile_time，client会出core
2. 修改了brpc_client.cpp及gemeral_model.cpp，添加了判断逻辑