### PR TITLE
Add new feature PaddleServing and Pipeline stop command

### DIFF
--- a/python/paddle_serving_server/env.py
+++ b/python/paddle_serving_server/env.py
@@ -1,0 +1,52 @@
+# coding:utf-8
+# Copyright (c) 2020  PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''
+This module is used to store environmental variables in PaddleServing.
+
+
+SERVING_HOME              -->  the root directory for storing Paddleserving related data. Default to the current directory of starting PaddleServing . Users can
+                               change the default value through the SERVING_HOME environment variable.
+CONF_HOME                 -->  Store the default configuration files.
+
+'''
+
+import os
+import sys
+
+def _get_user_home():
+    return os.path.expanduser(os.getcwd())
+
+
+def _get_serving_home():
+    if 'SERVING_HOME' in os.environ:
+        home_path = os.environ['SERVING_HOME']
+        if os.path.exists(home_path):
+            if os.path.isdir(home_path):
+                return home_path
+            else:
+                raise RuntimeError('The environment variable SERVING_HOME {} is not a directory.'.format(home_path))
+        else:
+            return home_path
+    return os.path.join(_get_user_home())
+
+
+def _get_sub_home(directory):
+    home = os.path.join(_get_serving_home(), directory)
+    if not os.path.exists(home):
+        os.makedirs(home)
+    return home
+
+SERVING_HOME = _get_serving_home()
+CONF_HOME = _get_sub_home("")

--- a/python/paddle_serving_server/util.py
+++ b/python/paddle_serving_server/util.py
@@ -1,0 +1,125 @@
+# coding:utf-8
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import signal
+import os
+import time
+import json
+from paddle_serving_server.env import CONF_HOME
+
+
+def pid_is_exist(pid: int):
+    '''
+    Try to kill process by PID.
+
+    Args:
+        pid(int): PID of process to be killed.
+
+    Returns:
+         True if PID will be killed.
+
+    Examples:
+    .. code-block:: python
+
+        pid_is_exist(pid=8866)
+    '''
+    try:
+        os.kill(pid, 0)
+    except:
+        return False
+    else:
+        return True
+
+def kill_stop_process_by_pid(command : str, pid : int):
+    '''
+    using different signals to kill process group by PID .
+
+    Args:
+        command(str): stop->SIGINT, kill->SIGKILL
+        pid(int): PID of process to be killed.
+
+    Returns:
+       None
+    Examples:
+    .. code-block:: python
+
+       kill_stop_process_by_pid("stop", 9494)
+    '''
+    if not pid_is_exist(pid):
+        print("Process [%s]  has been stopped."%pid)
+        return
+    try:
+         if command == "stop":
+             os.killpg(pid, signal.SIGINT)
+         elif command == "kill":
+             os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+         if command == "stop":
+             os.kill(pid, signal.SIGINT)
+         elif command == "kill":
+             os.kill(pid, signal.SIGKILL)
+
+def dump_pid_file(portList, model):
+    '''
+    Write PID info to file.
+
+    Args:
+        portList(List): PiplineServing includes http_port and rpc_port
+                        PaddleServing include one port
+        model(str): 'Pipline' for PiplineServing
+                    Specific model list for ServingModel 
+
+    Returns:
+       None
+    Examples:
+    .. code-block:: python
+
+       dump_pid_file([9494, 10082], 'serve')
+    '''
+    pid = os.getpid()
+    pidInfoList = []
+    filepath = os.path.join(CONF_HOME, "ProcessInfo.json")
+    if os.path.exists(filepath):
+        if os.path.getsize(filepath):
+            with open(filepath, "r") as fp:
+                pidInfoList = json.load(fp)
+                # delete old pid data when new port number is same as old's
+                for info in pidInfoList:
+                    storedPort = list(info["port"])
+                    interList = list(set(portList)&set(storedPort))
+                    if interList:
+                        pidInfoList.remove(info)
+
+    with open(filepath, "w") as fp:
+        info ={"pid": pid, "port" : portList, "model" : str(model), "start_time" : time.time()}
+        pidInfoList.append(info)
+        json.dump(pidInfoList, fp)
+
+def load_pid_file(filepath: str):
+    '''
+    Read PID info from file.
+    '''
+    if not os.path.exists(filepath):
+        raise ValueError(
+            "ProcessInfo.json file is not exists, All processes of PaddleServing has been stopped.")
+        return False
+    
+    if os.path.getsize(filepath):
+        with open(filepath, "r") as fp:
+            infoList = json.load(fp)
+            return infoList
+    else:
+        os.remove(filepath)
+        print("ProcessInfo.json file is empty, All processes of PaddleServing has been stopped.")
+        return False


### PR DESCRIPTION
realize the command   `python3 -m paddle_serving_server.serve kill/stop [--port 9495]` to stop PaddleServing and PipelineServing uniformly.  