### PR TITLE
Update CMakeLists.txt for ascend310

### DIFF
--- a/core/general-server/CMakeLists.txt
+++ b/core/general-server/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(serving pdserving)
 target_link_libraries(serving cube-api)
 target_link_libraries(serving utils)
 target_link_libraries(serving utf8proc)
-if(WITH_ASCEND_CL)
+if(WITH_ASCEND_CL AND NOT WITH_LITE)
     target_link_libraries(serving ascendcl acl_op_compiler)
 endif()
 


### PR DESCRIPTION
1. 添加判断条件，在WITH_LITE=ON时不依赖ascend_cl库。因为此时LITE使用NNAdapter适配硬件，无需inference、serving部分依赖昇腾相关库