### PR TITLE
add suffix of model&params in paddle_engine

### DIFF
--- a/paddle_inference/paddle/include/paddle_engine.h
+++ b/paddle_inference/paddle/include/paddle_engine.h
@@ -166,8 +166,8 @@ class PaddleInferenceEngine : public EngineCore {
     }
 
     Config config;
-    std::vector<std::string> suffixParaVector = {".pdiparams", "__params__"};
-    std::vector<std::string> suffixModelVector = {".pdmodel", "__model__"};
+    std::vector<std::string> suffixParaVector = {".pdiparams", "__params__", "params"};
+    std::vector<std::string> suffixModelVector = {".pdmodel", "__model__", "model"};
     std::string paraFileName = getFileBySuffix(model_path, suffixParaVector);
     std::string modelFileName = getFileBySuffix(model_path, suffixModelVector);
 


### PR DESCRIPTION
1. 在paddle_engine.h读取模型文件逻辑中，在后缀列表中添加model和params