### PR TITLE
Update setup.py.app.in for sentencepiece

### DIFF
--- a/python/setup.py.app.in
+++ b/python/setup.py.app.in
@@ -44,7 +44,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.10.0',
     'pillow',
     'pyclipper', 'shapely',
-    'sentencepiece<=0.1.92; platform_machine != "aarch64"',
+    'sentencepiece<=0.1.96; platform_machine != "aarch64"',
     'sentencepiece; platform_machine == "aarch64"',
     'opencv-python<=4.2.0.32; platform_machine != "aarch64"',
     'opencv-python; platform_machine == "aarch64"',


### PR DESCRIPTION
1. 更新setup.py.app.in中sentencepiece最高版本要求，从0.1.92升级至0.1.96，用于适配python3.9