### PR TITLE
relocate import av in pptsn_reader

### DIFF
--- a/python/paddle_serving_app/reader/pptsn_reader.py
+++ b/python/paddle_serving_app/reader/pptsn_reader.py
@@ -1,20 +1,19 @@
 import numpy as np
-import av
 import cv2
 import pickle
-import decord as de
 import math
 import random
 
 import os
 
 from PIL import Image
-import SimpleITK as sitk
-
 
 try:
     import cPickle as pickle
     from cStringIO import StringIO
+    import av
+    import decord as de
+    import SimpleITK as sitk
 except ImportError:
     import pickle
     from io import BytesIO


### PR DESCRIPTION
- 修改pptsn_reader中引入av,decord,SimpleITK的位置，避免其依赖影响app.reader，使得在arm机器中因无法安装相应库而无法使用