### PR TITLE
general_response_op.cpp 支持新的返回类型

### DIFF
--- a/core/general-server/op/general_response_op.cpp
+++ b/core/general-server/op/general_response_op.cpp
@@ -183,6 +183,13 @@ int GeneralResponseOp::inference() {
         VLOG(2) << "(logid=" << log_id << ")Prepare float16 var ["
                 << model_config->_fetch_name[idx] << "].";
         tensor->set_tensor_content(in->at(idx).data.data(), in->at(idx).data.length());
+      } else {
+        // dType is not in paddle::PaddleDType, It's not return type of Paddle Inference.
+        // Copy all fields of Input data to output tensor.
+        VLOG(2) << "(logid=" << log_id << ")Prepare SPECIAL TYPE=" << dtype << " var ["
+                << model_config->_fetch_name[idx] << "].";
+        tensor->set_elem_type(dtype);
+        tensor->set_tensor_content(in->at(idx).data.data(), in->at(idx).data.length());
       }
 
       VLOG(2) << "(logid=" << log_id << ") fetch var ["


### PR DESCRIPTION
general_response_op中对非paddle::PaddleDType的输入做适配，目前可支持String类型返回。同时要求Client和Server的prototxt文件中增加对应fetch var ，类型同为string。

这里存在一个潜在问题，paddle::PaddleDType 与 Serving proto中定义的Tensor 类型不一致。因此要求，在非ResponseOp，且最后一个op是general_response_op时，优先使用paddle::PaddleDType，除非使用非paddle::PaddleDType 定义类型。

或者不使用ResponseOp，自由定义自己的返回Op。